### PR TITLE
Use gpg key from GitHub

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -73,7 +73,7 @@ sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyring
 travis_run curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 # Adding ubuntu toolchain
-travis_run add-apt-repository ppa:ubuntu-toolchain-r/test
+travis_run add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 # Update the sources again
 travis_run apt-get -qq update

--- a/travis.sh
+++ b/travis.sh
@@ -66,6 +66,7 @@ echo "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'
 travis_run apt-get -qq update
 travis_run apt-get install -y gnupg
 travis_run apt-get install -y software-properties-common
+travis_run apt-get install -y curl
 
 # Adding ros repo
 echo "Adding ros repo to apt sources"

--- a/travis.sh
+++ b/travis.sh
@@ -69,8 +69,8 @@ travis_run apt-get install -y software-properties-common
 
 # Adding ros repo
 echo "Adding ros repo to apt sources"
-sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $UBUNTU_VERSION main\" > /etc/apt/sources.list.d/ros-latest.list"
-travis_run apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros/ubuntu $UBUNTU_VERSION main" > /etc/apt/sources.list.d/ros-latest.list'
+travis_run curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
 # Adding ubuntu toolchain
 travis_run add-apt-repository ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Due to unstable key servers
(I triggered the builds of https://github.com/coincar-sim/lanelet_rviz_plugin_ros/pull/16 3 times and each stage has been successful already, but not both at the same time (see also [docker-library faq](https://github.com/docker-library/faq#openpgp--gnupg-keys-and-verification) and [this Blog](https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html))),
I changed `travis.sh` to use gpg keys directly, as also [suggested for ROS2](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Binary.html) (using [OpenPGP](https://keys.openpgp.org/about/usage) would another be a solution).